### PR TITLE
README: corrected grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ You can either compile Otter Browser from source by following the instructions i
 
 ### Under Linux and *BSD
 
-Linux users can use the official AppImage version available on [SourceForge](https://sourceforge.net/projects/otter-browser/files/). It is a single executable file that doesn’t need any dependencies to be installed. The AppImage version should run under any system installed after 2012. The browser is also available in a the repositories of a wide range of Linux distributions and *BSD systems. Read more on [the dedicated wiki page](https://github.com/OtterBrowser/otter-browser/wiki/Packages).
+Linux users can use the official AppImage version available at [SourceForge](https://sourceforge.net/projects/otter-browser/files/). It is a single executable file that doesn’t need any dependencies to be installed. The AppImage version should run under any system installed after 2012. The browser is also available in a the repositories of a wide range of Linux distributions and *BSD systems. Read more on [the dedicated wiki page](https://github.com/OtterBrowser/otter-browser/wiki/Packages).
 
 ### Under Windows
 
-Windows users can download binary releases on [SourceForge](https://sourceforge.net/projects/otter-browser/files/).
+Windows users can download binary releases from [SourceForge](https://sourceforge.net/projects/otter-browser/files/).
 
 ### Under macOS
 
-DMG packages are available on [SourceForge](https://sourceforge.net/projects/otter-browser/files/).
+DMG packages are available at [SourceForge](https://sourceforge.net/projects/otter-browser/files/).
 
 ## How to contribute
 


### PR DESCRIPTION
 'at SourceForge' and 'from SourceForge' seems to be more correct.